### PR TITLE
Locale config can be a function as well

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -20,7 +20,10 @@ if (!function_exists('nova_lang_get_active_locale')) {
 if (!function_exists('nova_lang_get_all_locales')) {
     function nova_lang_get_all_locales()
     {
-        return config('nova-lang.locales');
+        $locales = config('nova-lang.locales', ['en' => 'English']);
+        if (is_callable($locales)) return call_user_func($locales);
+        if (is_array($locales)) return $locales;
+        return ['en' => 'English'];
     }
 }
 


### PR DESCRIPTION
First of all, thanks for having a such a great collection of nova packages.

This PR, will make sure that locale configuration can be a function, which is pretty handy, if you are using with [nova-locale-manager](https://github.com/optimistdigital/nova-locale-manager) package.

In `nova-lang.php` it can be used:

```
'locales' => function() {
    return nova_get_locales();
}
```
